### PR TITLE
Upgrade Java version to 21 on iteration 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,24 +5,33 @@
     <artifactId>download-server</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <properties>
+        <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>4.1.1.RELEASE</spring.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.2.3.RELEASE</version>
+        <version>3.0.13</version>
         <relativePath/>
     </parent>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>2.4.16</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.0</version>
+                <version>3.14.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
         </plugins>
@@ -38,7 +47,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -61,22 +70,24 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
+            <version>1.17.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>1.2.3.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>1.2.3.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>1.2.3.RELEASE</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>
@@ -90,11 +101,17 @@
             <artifactId>spock-core</artifactId>
             <version>1.0-groovy-2.4</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>29.0-jre</version>
         </dependency>
         <dependency>
             <groupId>cglib</groupId>
@@ -104,53 +121,46 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context-support</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-expression</artifactId>
-            <version>4.1.6.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>4.1.6.RELEASE</version>
-            <scope>test</scope>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/nurkiewicz/download/DownloadController.java
+++ b/src/main/java/com/nurkiewicz/download/DownloadController.java
@@ -1,6 +1,5 @@
 package com.nurkiewicz.download;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +24,6 @@ public class DownloadController {
 
 	private final FileStorage storage;
 
-	@Autowired
 	public DownloadController(FileStorage storage) {
 		this.storage = storage;
 	}

--- a/src/main/java/com/nurkiewicz/download/MainApplication.java
+++ b/src/main/java/com/nurkiewicz/download/MainApplication.java
@@ -7,7 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 class MainApplication {
 
 	public static void main(String[] args) {
-		Integer temp = new Integer("1234");
+		Integer temp = Integer.valueOf("1234");
 		SpringApplication.run(MainApplication.class, args);
 	}
 }


### PR DESCRIPTION
# Java Version Upgrade - Code Transformation Summary 🔄

## Executive Summary 📋
A Java application transformation was performed using OPENREWRITE to modernize dependencies and framework versions. The transformation resulted in significant dependency updates, particularly in Spring Framework components from 4.1.6 to 6.0.23. The process completed with build failures that require attention. Confidence in the transformation is moderate, suggesting careful validation is needed.

## Next Steps ⏭️
- 🔍 Investigate and resolve build failures
- ✅ Validate all dependency version compatibility
- 🧪 Perform comprehensive testing of modified components
- 📝 Review and update any deprecated API usage
- 🚀 Plan for deployment after successful build

## Key Metrics 📊
- ⏱️ Transform Duration: 7 minutes
- 💡 Estimated Time Saved: 17 minutes
- 📈 Confidence Level: Medium
- 📝 Lines Modified: 64
- 📂 Files Changed: 3
- 📦 Dependencies Modified: 18

## Build Summary 🏗️
- Status: ❌ FAILURE
- Engine: OPENREWRITE
- Framework: Java

## Dependencies 📚

### Added ➕
- 🆕 jakarta.servlet:jakarta.servlet-api (LATEST)

### Removed ➖
- None

### Upgraded ⬆️
- 🔄 Spring Framework components (4.1.6.RELEASE → 6.0.23)
  - spring-test, spring-beans, spring-context, spring-webmvc, etc.
- 🔄 Spring Boot components (1.2.3.RELEASE → LATEST/3.0.13)
  - spring-boot-starter-web, actuator, test
- 🔄 Other Dependencies
  - commons-codec (1.10 → 1.17.2)
  - guava (18.0 → 29.0-jre)
  - groovy-all (2.4.3 → LATEST)
  - maven-compiler-plugin (3.0 → 3.14.0)

## Modified Files 📝
1. pom.xml
2. src/main/java/com/nurkiewicz/download/DownloadController.java
3. src/main/java/com/nurkiewicz/download/MainApplication.java