### PR TITLE
Upgrade Java version to 21 on iteration 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,24 +5,33 @@
     <artifactId>download-server</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <properties>
+        <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>4.1.1.RELEASE</spring.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.2.3.RELEASE</version>
+        <version>3.0.13</version>
         <relativePath/>
     </parent>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>2.4.16</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.0</version>
+                <version>3.15.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
         </plugins>
@@ -38,7 +47,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -61,22 +70,24 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
+            <version>1.17.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>1.2.3.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>1.2.3.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>1.2.3.RELEASE</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>
@@ -90,11 +101,17 @@
             <artifactId>spock-core</artifactId>
             <version>1.0-groovy-2.4</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>29.0-jre</version>
         </dependency>
         <dependency>
             <groupId>cglib</groupId>
@@ -104,53 +121,46 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context-support</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-expression</artifactId>
-            <version>4.1.6.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>4.1.6.RELEASE</version>
-            <scope>test</scope>
+            <version>6.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/nurkiewicz/download/DownloadController.java
+++ b/src/main/java/com/nurkiewicz/download/DownloadController.java
@@ -1,6 +1,5 @@
 package com.nurkiewicz.download;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +24,6 @@ public class DownloadController {
 
 	private final FileStorage storage;
 
-	@Autowired
 	public DownloadController(FileStorage storage) {
 		this.storage = storage;
 	}

--- a/src/main/java/com/nurkiewicz/download/MainApplication.java
+++ b/src/main/java/com/nurkiewicz/download/MainApplication.java
@@ -7,7 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 class MainApplication {
 
 	public static void main(String[] args) {
-		Integer temp = new Integer("1234");
+		Integer temp = Integer.valueOf("1234");
 		SpringApplication.run(MainApplication.class, args);
 	}
 }


### PR DESCRIPTION
# 📋 Executive Report: Java Modernization Upgrade  
  
## 🔍 Executive Summary  
  
A legacy Java 8 / Spring Boot 1.2.3 download-server application was successfully modernized to **Java 21** and **Spring Boot 3.0.13** using a fully automated pipeline combining OpenRewrite recipes and Amazon Kiro CLI. The upgrade spanned multiple major framework generations — Java 8 → 11 → 17 → 21 and Spring Boot 1.x → 2.x → 3.x — and completed with a clean build and all tests passing. No manual code changes were required beyond what the automated tooling applied.  
  
---  
  
## 🏗️ Application Changes  
  
- 📦 **Project**: `com.nurkiewicz.download:download-server` — a Spring MVC file download service  
- ☕ **Java**: `1.8` (source/target) → `21` (compiler release)  
- 🌱 **Spring Boot**: `1.2.3.RELEASE` → `3.0.13`  
- 🔧 **Spring Framework**: `4.1.6.RELEASE` → `6.0.23`  
- 🔌 **Maven Compiler Plugin**: `3.0` → `3.15.0` (with `<release>` configuration replacing `<source>`/`<target>`)  
- 🔒 **commons-codec**: upgraded to `1.17.2` (security patch)  
- 🛡️ **Jakarta EE migration**: `javax.servlet` → `jakarta.servlet` (added `jakarta.servlet-api` dependency)  
- 🧹 **Duplicate dependency removed**: duplicate `spring-test` declaration cleaned up  
- 🚫 **`@Autowired` removed** from constructor in `DownloadController` (Spring Boot best practice)  
- 🔢 **`Integer(String)` constructor** replaced with `Integer.valueOf(String)` in `MainApplication` (deprecated API fix)  
  
---  
  
## 🛠️ Tools Used  
  
- ☕ **Java SDK 21** — target runtime and compile target for the modernized application  
- 🔄 **OpenRewrite 6.35.0** — automated recipe engine driving all source and POM transformations  
  - Recipe: `com.amazonaws.java.migrate.UpgradeToJava21` — Java 8 → 21 migration (185 recipe steps)  
  - Recipe: `com.amazonaws.java.spring.boot3.UpgradeSpringBoot_3_0` — Spring Boot 1.x → 3.0 migration (616 recipe steps)  
- 🤖 **Amazon Kiro CLI `v1.29.0`** (model: `claude-sonnet-4-5`) — post-migration build verification, error triage, and report generation  
- 🏗️ **Apache Maven** (via `mvnw` wrapper) — build and test execution  
  
---  
  
## 💻 Code Changes  
  
| File | Change |  
|------|--------|  
| `pom.xml` | Java version `1.8` → `21`; Spring Boot parent `1.2.3` → `3.0.13`; Spring Framework `4.1.6` → `6.0.23`; compiler plugin `3.0` → `3.15.0`; commons-codec → `1.17.2`; added `jakarta.servlet-api`; removed duplicate `spring-test` |  
| `MainApplication.java` | `new Integer("1234")` → `Integer.valueOf("1234")` (deprecated constructor removed) |  
| `DownloadController.java` | `@Autowired` annotation removed from constructor (Spring Boot 3 best practice) |  
  
---  
  
## ⏱️ Time Savings Estimate  
  
| Phase | Automated Estimate | Notes |  
|-------|--------------------|-------|  
| Java 8 → 21 migration | **~50 minutes** | Per OpenRewrite run stats |  
| Spring Boot 1.x → 3.0 migration | **~1 hour 47 minutes** | Per OpenRewrite run stats |  
| Build verification & fix | **~15 minutes** | Kiro CLI automated triage |  
| **Total estimated savings** | **~2.5 hours** | vs. manual migration effort |  
  
- 🧮 Manual equivalent effort for this scope (multi-generation Spring + Java upgrade) would typically range **4–8 hours** for an experienced engineer  
- 🚀 Automated pipeline completed end-to-end in under **6 minutes** of wall-clock time  
  
---  
  
## ✅ Next Steps  
  
### Validation  
- 🧪 Run the full test suite in a staging environment with real file system access to validate `FileSystemStorage` and `ThrottlingInputStream` behavior end-to-end  
- 🔍 Address the remaining deprecation warning in `FileSystemPointer` (`Hashing.sha512()` from Guava — consider migrating to `java.security.MessageDigest`)  
- 📋 Review Groovy/Spock test compatibility — the OpenRewrite run flagged parse warnings on `DownloadControllerTest.groovy`; consider upgrading Spock to `2.x` with Groovy `4.x` for full Java 21 support  
  
### Improvements  
- ⬆️ Upgrade `spock-core` / `spock-spring` from `1.0-groovy-2.4` to `2.3+` — current version is incompatible with Java 21 module system long-term  
- 🔐 Upgrade `com.google.guava` beyond `29.0-jre` (current latest is `33.x`) to pick up security and API improvements  
- 🗑️ Remove `cglib-nodep:3.1` — Spring Boot 3 / Spring Framework 6 uses `spring-aop` with built-in CGLIB; the standalone dependency is redundant  
- 📦 Consider replacing `commons-io` `2.4` with the current `2.16+` release  
- 🏷️ Pin `spring.version` property (`4.1.1.RELEASE`) which is now stale and unused — remove to avoid confusion  
