### PR TITLE
Upgrade Java version to 25 on iteration 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,24 +5,75 @@
     <artifactId>download-server</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <properties>
+        <argLine></argLine>
+        <java.version>25</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>4.1.1.RELEASE</spring.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.2.3.RELEASE</version>
+        <version>3.5.0</version>
         <relativePath/>
     </parent>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.groovy</groupId>
+                <artifactId>groovy-bom</artifactId>
+                <version>4.0.32</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <skipBytecodeCheck>true</skipBytecodeCheck>
+                    <targetBytecode>21</targetBytecode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compileTests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.0</version>
+                <version>3.15.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!--suppress MavenModelInspection -->
+                    <argLine>@{argLine} -javaagent:${net.bytebuddy:byte-buddy-agent:jar}</argLine>
+                    <includes>
+                        <include>**/*Spec.class</include>
+                        <include>**/*Test.class</include>
+                    </includes>
                 </configuration>
             </plugin>
         </plugins>
@@ -36,21 +87,9 @@
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>4.1.6.RELEASE</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-spring</artifactId>
-            <version>1.0-groovy-2.4</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy-all</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>2.3-groovy-4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -61,96 +100,36 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
+            <version>1.17.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>1.2.3.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>1.2.3.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>1.2.3.RELEASE</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-test</artifactId>
-                </exclusion>
-            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>1.0-groovy-2.4</version>
+            <version>2.3-groovy-4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>29.0-jre</version>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-            <version>4.1.6.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>4.1.6.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context-support</artifactId>
-            <version>4.1.6.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-webmvc</artifactId>
-            <version>4.1.6.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>4.1.6.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-aop</artifactId>
-            <version>4.1.6.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>4.1.6.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-expression</artifactId>
-            <version>4.1.6.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.4.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/nurkiewicz/download/DownloadController.java
+++ b/src/main/java/com/nurkiewicz/download/DownloadController.java
@@ -1,6 +1,5 @@
 package com.nurkiewicz.download;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +24,6 @@ public class DownloadController {
 
 	private final FileStorage storage;
 
-	@Autowired
 	public DownloadController(FileStorage storage) {
 		this.storage = storage;
 	}

--- a/src/main/java/com/nurkiewicz/download/MainApplication.java
+++ b/src/main/java/com/nurkiewicz/download/MainApplication.java
@@ -7,7 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 class MainApplication {
 
 	public static void main(String[] args) {
-		Integer temp = new Integer("1234");
+		Integer temp = Integer.valueOf("1234");
 		SpringApplication.run(MainApplication.class, args);
 	}
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,15 +1,17 @@
 <configuration>
 
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} | %thread | %-5level | %logger{1} | %msg%n</pattern>
+        </encoder>
+    </appender>
+
     <logger name="com" level="INFO"/>
     <logger name="com.nurkiewicz" level="ALL"/>
     <logger name="net" level="INFO"/>
     <logger name="org" level="INFO"/>
 
     <root level="DEBUG">
-        <appender class="ch.qos.logback.core.ConsoleAppender">
-            <encoder>
-                <pattern>%d{HH:mm:ss.SSS} | %thread | %-5level | %logger{1} | %msg%n</pattern>
-            </encoder>
-        </appender>
+        <appender-ref ref="CONSOLE"/>
     </root>
 </configuration>

--- a/src/test/groovy/com/nurkiewicz/download/DownloadControllerTest.groovy
+++ b/src/test/groovy/com/nurkiewicz/download/DownloadControllerTest.groovy
@@ -1,12 +1,11 @@
 package com.nurkiewicz.download
 
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.web.WebAppConfiguration
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
-import org.springframework.web.context.WebApplicationContext
 import spock.lang.Specification
 
 import java.time.Instant
@@ -19,25 +18,27 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 
-@WebAppConfiguration
+@SpringBootTest
+@AutoConfigureMockMvc
 @ContextConfiguration(classes = [MainApplication])
 @ActiveProfiles("test")
 class DownloadControllerSpec extends Specification {
 
-	private MockMvc mockMvc
-
-	private static final String TEXT_FILE = '/download/' + FileExamples.TXT_FILE_UUID + '/file.txt';
+	@Autowired
+	MockMvc mockMvc
 
 	@Autowired
-	public void setWebApplicationContext(WebApplicationContext wac) {
-		mockMvc = MockMvcBuilders.webAppContextSetup(wac).build()
-	}
+	FileStorage fileStorage
+
+	String textFile() { '/download/' + FileExamples.TXT_FILE_UUID + '/file.txt' }
+
+	FilePointer txtFile() { fileStorage.findFile(FileExamples.TXT_FILE_UUID).get() }
 
 	def 'should return bytes of existing file'() {
 		expect:
 			mockMvc
 					.perform(
-						get(TEXT_FILE))
+						get(textFile()))
 					.andExpect(status().isOk())
 					.andExpect(content().string("foobar"))
 	}
@@ -55,7 +56,7 @@ class DownloadControllerSpec extends Specification {
 		expect:
 			mockMvc
 					.perform(
-						get(TEXT_FILE))
+						get(textFile()))
 					.andExpect(
 						status().isOk())
 		}
@@ -64,7 +65,7 @@ class DownloadControllerSpec extends Specification {
 		expect:
 			mockMvc
 					.perform(
-						get(TEXT_FILE)
+						get(textFile())
 								.header(IF_NONE_MATCH, '"WHATEVER"'))
 					.andExpect(
 						status().isOk())
@@ -72,11 +73,11 @@ class DownloadControllerSpec extends Specification {
 
 	def 'should not send file if ETag matches content'() {
 		given:
-			String etag = FileExamples.TXT_FILE.getEtag()
+			String etag = txtFile().getEtag()
 		expect:
 			mockMvc
 					.perform(
-						get(TEXT_FILE)
+						get(textFile())
 								.header(IF_NONE_MATCH, etag))
 					.andExpect(
 						status().isNotModified())
@@ -86,12 +87,12 @@ class DownloadControllerSpec extends Specification {
 
 	def 'should not return file if wasn\'t modified recently'() {
 		given:
-			Instant lastModified = FileExamples.TXT_FILE.getLastModified()
+			Instant lastModified = txtFile().getLastModified()
 			String dateHeader = toDateHeader(lastModified)
 		expect:
 			mockMvc
 					.perform(
-					get(TEXT_FILE)
+					get(textFile())
 							.header(IF_MODIFIED_SINCE, dateHeader))
 					.andExpect(
 							status().isNotModified())
@@ -99,12 +100,12 @@ class DownloadControllerSpec extends Specification {
 
 	def 'should not return file if server has older version than the client'() {
 		given:
-			Instant lastModifiedLaterThanServer = FileExamples.TXT_FILE.getLastModified().plusSeconds(60)
+			Instant lastModifiedLaterThanServer = txtFile().getLastModified().plusSeconds(60)
 			String dateHeader = toDateHeader(lastModifiedLaterThanServer)
 		expect:
 			mockMvc
 					.perform(
-					get(TEXT_FILE)
+					get(textFile())
 							.header(IF_MODIFIED_SINCE, dateHeader))
 					.andExpect(
 							status().isNotModified())
@@ -112,12 +113,12 @@ class DownloadControllerSpec extends Specification {
 
 	def 'should return file if was modified after last retrieval'() {
 		given:
-			Instant lastModifiedRecently = FileExamples.TXT_FILE.getLastModified().minusSeconds(60)
+			Instant lastModifiedRecently = txtFile().getLastModified().minusSeconds(60)
 			String dateHeader = toDateHeader(lastModifiedRecently)
 		expect:
 			mockMvc
 					.perform(
-					get(TEXT_FILE)
+					get(textFile())
 							.header(IF_MODIFIED_SINCE, dateHeader))
 					.andExpect(
 							status().isOk())
@@ -127,7 +128,7 @@ class DownloadControllerSpec extends Specification {
 		expect:
 			mockMvc
 					.perform(
-						head(TEXT_FILE))
+						head(textFile()))
 					.andExpect(
 							status().isOk())
 					.andExpect(
@@ -138,30 +139,30 @@ class DownloadControllerSpec extends Specification {
 		expect:
 			mockMvc
 				.perform(
-					head(TEXT_FILE)
-							.header(IF_NONE_MATCH, FileExamples.TXT_FILE.getEtag()))
+					head(textFile())
+							.header(IF_NONE_MATCH, txtFile().getEtag()))
 				.andExpect(
 					status().isNotModified())
 				.andExpect(
-					header().string(ETAG, FileExamples.TXT_FILE.getEtag()))
+					header().string(ETAG, txtFile().getEtag()))
 	}
 
 	def 'should return Content-length header'() {
 		expect:
 			mockMvc
 					.perform(
-					head(TEXT_FILE))
+					head(textFile()))
 					.andExpect(
 					status().isOk())
 					.andExpect(
-					header().longValue(CONTENT_LENGTH, FileExamples.TXT_FILE.size))
+					header().longValue(CONTENT_LENGTH, txtFile().size))
 	}
 
 	def 'should return content type in response'() {
 		expect:
 			mockMvc
 					.perform(
-					head(TEXT_FILE))
+					head(textFile()))
 					.andExpect(
 					status().isOk())
 					.andExpect(

--- a/src/test/java/org/springframework/web/filter/Sha512ShallowEtagHeaderFilter.java
+++ b/src/test/java/org/springframework/web/filter/Sha512ShallowEtagHeaderFilter.java
@@ -2,12 +2,16 @@ package org.springframework.web.filter;
 
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 public class Sha512ShallowEtagHeaderFilter extends ShallowEtagHeaderFilter {
 
 	@Override
-	protected String generateETagHeaderValue(byte[] bytes) {
-		final HashCode hash = Hashing.sha512().hashBytes(bytes);
+	protected String generateETagHeaderValue(InputStream inputStream, boolean isWeak) throws IOException {
+		final HashCode hash = Hashing.sha512().hashBytes(IOUtils.toByteArray(inputStream));
 		return "\"" + hash + "\"";
 	}
 }

--- a/summary.md
+++ b/summary.md
@@ -1,0 +1,38 @@
+# Summary
+
+## Status
+Build passes: ✅  
+Tests: 12 run, 0 failures, 0 errors
+
+## Changes Made
+
+### 1. `pom.xml` — Major upgrades
+- **Spring Boot**: 3.0.13 → 3.5.0 (required for ASM that supports Java 25 class files)
+- **Groovy**: `org.codehaus.groovy:groovy-all:2.4.16` → `org.apache.groovy:groovy:4.0.32` (via BOM; Groovy 4 supports Java 25 runtime)
+- **Spock**: 1.0-groovy-2.4 → 2.3-groovy-4.0 (Spock 2.x targets JUnit 5 Platform)
+- **Surefire**: 2.22.2 → 3.2.5 (needed for proper JUnit Platform / Spock 2 test discovery)
+- Added `gmavenplus-plugin:3.0.2` to compile `.groovy` test sources (was missing entirely)
+  - `skipBytecodeCheck=true` — Groovy 4.0.32 does not yet enumerate Java 25 as a known bytecode target
+  - `targetBytecode=21` — Spring's ASM component scans test classpath; compiling Groovy tests to Java 25 bytecode causes an `Unsupported class file major version 69` error during context loading
+- Removed explicit Spring version overrides (spring-beans, spring-core, etc. @ 6.0.23); Spring Boot 3.5.0 manages Spring 6.2.7
+- Removed `cglib-nodep:3.1` (bundled in Spring since Spring 6)
+- Removed `jakarta.servlet-api` explicit test dependency (managed by Spring Boot)
+- Removed `spring-test` explicit dependency and its exclusion from `spring-boot-starter-test`
+
+### 2. `src/main/resources/logback.xml` — Fix invalid configuration
+The appender was defined inline inside `<root>` which is invalid Logback XML syntax (causes `IllegalStateException: Logback configuration error detected` on Spring Boot startup). Moved `<appender>` to top level and referenced via `<appender-ref>`.
+
+### 3. `src/test/groovy/.../DownloadControllerTest.groovy` — Modernise test
+- Replaced `@WebAppConfiguration` + `@ContextConfiguration` + manual `MockMvcBuilders.webAppContextSetup()` with `@SpringBootTest` + `@AutoConfigureMockMvc` + `@Autowired MockMvc`
+- Added `@ContextConfiguration(classes = [MainApplication])` alongside `@SpringBootTest` — required because Spock 2's `SpringExtension.isSpringSpec()` checks for `@ContextConfiguration` directly (the `MetaAnnotationUtils.findAnnotationDescriptorForTypes` path used to detect `@BootstrapWith`/`@SpringBootTest` was removed in Spring 6)
+- Replaced `static final TEXT_FILE` field (evaluated at Groovy class-load time, before Spring context, causing UUID mismatch) with `textFile()` and `txtFile()` methods evaluated at test-execution time within the Spring context classloader
+- Injected `FileStorage` bean and used it to resolve `FilePointer` from the live Spring context (eliminates the static `FileExamples.TXT_FILE` classloader split)
+
+### 4. `src/test/java/.../Sha512ShallowEtagHeaderFilter.java` — Fix overridden method signature
+`ShallowEtagHeaderFilter.generateETagHeaderValue` signature changed from `(byte[])` to `(InputStream, boolean) throws IOException` in Spring 6. Updated override accordingly.
+
+## Next Steps
+- The `Hashing.sha512()` method in Guava 29 is `@Deprecated`; consider upgrading Guava (current: 29.0-jre) to 33.x and switching to `Hashing.sha512()` or `MessageDigest`-based approach — however this is a separate concern from the Java 25 upgrade.
+- The `commons-io` dependency is pinned at 2.4 (released 2012); consider upgrading to 2.16+.
+- The `skipBytecodeCheck=true` in GMavenPlus is a workaround until Groovy adds official Java 25 bytecode support.
+- Groovy test classes are compiled to Java 21 bytecode (`targetBytecode=21`) while the main application targets Java 25. This is intentional: Spring's internal ASM classfile parser is used during component scanning of `target/test-classes`, and Spring 6.2.7's ASM tops out at Java 25 (V25 present but may have edge cases). Monitor for issues when upgrading Spring Boot further.


### PR DESCRIPTION
# Java 25 Upgrade — Executive Report  
  
---  
  
## 🎯 Executive Summary  
  
The `download-server` Spring Boot application (originally built on Java 8, Spring Boot 1.x, and Groovy 2.4/Spock 1.0) was successfully upgraded to **Java 25** with a fully passing test suite. The process combined automated OpenRewrite recipe execution with targeted manual fixes by Amazon Kiro CLI. OpenRewrite handled the bulk structural migrations (pom version bumps, static analysis cleanups, Jakarta namespace migration), while Kiro resolved the remaining deep compatibility issues — including a Spring 6 ASM bytecode incompatibility, a Spock/Spring integration regression, invalid Logback XML, and a classloader UUID race condition in tests. The final build exits with **✅ BUILD SUCCESS — 12/12 tests passing, 0 failures**.  
  
---  
  
## 📦 Application Changes  
  
- 🏗️ **Application**: `com.nurkiewicz.download:download-server` — a file download REST API built with Spring Boot  
- 📁 **Source files**: 8 main Java sources, 2 Java test sources, 1 Groovy test spec  
- 🔄 **Starting state**: Java 8, Spring Boot 1.x, Spock 1.0 / Groovy 2.4, `javax.*` APIs  
- ✅ **End state**: Java 25, Spring Boot 3.5.0 / Spring 6.2.7, Spock 2.3 / Groovy 4.0.32, `jakarta.*` APIs  
  
---  
  
## 🛠️ Tools Used  
  
- ☕ **Java SDK**: OpenJDK 25 (compiler target `--release 25`)  
- 🔁 **OpenRewrite** `6.42.0` with recipes:  
  - `com.amazonaws.java.migrate.UpgradeToJava25` — incremental Java 8→11→17→21→25 migrations  
  - `com.amazonaws.java.spring.boot3.UpgradeSpringBoot_3_0` — full Spring Boot 1.x→3.0 migration chain including Jakarta namespace, JUnit 4→5, dependency upgrades  
- 🤖 **Amazon Kiro CLI** `v2.0.1` — post-rewrite build error remediation and test restoration  
- 🏗️ **Apache Maven** 3.9.8 via `mvnw` wrapper  
  
---  
  
## 🔧 Code Changes  
  
### `pom.xml`  
- ⬆️ Spring Boot parent: `3.0.13` → **`3.5.0`** (required for Spring 6.2.7 + ASM with Java 25 support)  
- ⬆️ Groovy: `org.codehaus.groovy:groovy-all:2.4.16` → **`org.apache.groovy:groovy:4.0.32`** (via BOM)  
- ⬆️ Spock: `1.0-groovy-2.4` → **`2.3-groovy-4.0`** (JUnit 5 Platform engine)  
- ⬆️ Surefire: `2.22.2` → **`3.2.5`** (proper JUnit Platform auto-detection)  
- ➕ Added **GMavenPlus plugin `3.0.2`** — Groovy test sources were never compiled (no plugin was configured); `skipBytecodeCheck=true` + `targetBytecode=21` required because Groovy 4.0.32 doesn't enumerate Java 25 yet, and Spring's ASM component scanner rejects Java 25 bytecode in test-classes  
- 🗑️ Removed explicit Spring 6.0.23 version overrides, `cglib-nodep`, `jakarta.servlet-api`, redundant `spring-test` dependency  
  
### `src/main/resources/logback.xml`  
- 🐛 Fixed invalid Logback XML — `<appender>` was illegally nested inside `<root>`, causing `IllegalStateException: Logback configuration error detected` on every Spring Boot startup; moved to top-level with `<appender-ref>`  
  
### `src/test/groovy/.../DownloadControllerTest.groovy`  
- 🔄 Replaced `@WebAppConfiguration` + `@ContextConfiguration` + manual `MockMvcBuilders.webAppContextSetup()` with `@SpringBootTest` + `@AutoConfigureMockMvc` + `@Autowired MockMvc`  
- ➕ Added `@ContextConfiguration(classes = [MainApplication])` — Spock 2's `SpringExtension.isSpringSpec()` relies on `MetaAnnotationUtils.findAnnotationDescriptorForTypes` (removed in Spring 6) to detect `@SpringBootTest`; adding `@ContextConfiguration` directly triggers the fallback detection path  
- 🐛 Fixed classloader UUID split — `static final TEXT_FILE` was evaluated at Groovy class-load time before Spring context setup, producing a different `UUID.randomUUID()` than the one loaded by the Spring context; replaced with `textFile()` and `txtFile()` methods evaluated at runtime within the live Spring context  
- ➕ Injected `FileStorage` bean to resolve `FilePointer` from the live context  
  
### `src/test/java/.../Sha512ShallowEtagHeaderFilter.java`  
- 🐛 Fixed overridden method signature — `generateETagHeaderValue(byte[])` changed to `generateETagHeaderValue(InputStream, boolean) throws IOException` in Spring 6  
  
---  
  
## ⏱️ Time Savings Estimate  
  
| Task | Manual Estimate | Automated |  
|---|---|---|  
| Java 8→25 version bumps + static analysis | ~2–3 h | ✅ OpenRewrite (~2 min) |  
| Spring Boot 1.x→3.0 migration (Jakarta, JUnit 5, pom) | ~1–2 days | ✅ OpenRewrite (~3 min) |  
| Post-rewrite build/test failure diagnosis & fixes | ~4–6 h | ✅ Kiro CLI (~42 min) |  
| **Total saved** | **~2–3 days** | **~45 min end-to-end** |  
  
> 💡 Estimated **~10–15× faster** than fully manual upgrade for a project of this complexity.  
  
---  
  
## 🚀 Next Steps  
  
### Validation  
- 🧪 Run the full test suite in CI against the target JDK 25 environment to confirm no environment-specific regressions  
- 🔍 Review OpenRewrite change diffs in source control before merging — particularly `DownloadController.java` (removed `@Autowired` on constructor) and `MainApplication.java` (`Integer.valueOf` replacement)  
  
### Improvement Recommendations  
- ⬆️ **Upgrade Guava** (`29.0-jre` → `33.x`) — `Hashing.sha512()` is `@Deprecated` in current Guava; used in both `FileSystemPointer` and `Sha512ShallowEtagHeaderFilter`  
- ⬆️ **Upgrade `commons-io`** (`2.4`, released 2012 → `2.16+`) to address known vulnerabilities  
- 🔧 **`skipBytecodeCheck=true`** in GMavenPlus is a workaround — remove once Groovy officially enumerates Java 25 as a known bytecode target  
- 📝 **Fix `FileExamples`** — replace `UUID.randomUUID()` static fields with a fixed deterministic UUID to eliminate classloader sensitivity in tests  
- 🗑️ Remove legacy `spring.version=4.1.1.RELEASE` property from `pom.xml` (orphaned, has no effect)  
- 🔄 Consider upgrading Spring Boot to a patch release (`3.5.x`) as they become available for ongoing security fixes  
