### PR TITLE
Upgrade Java version to 25 on iteration 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,12 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!--suppress MavenModelInspection -->
-                    <argLine>@{argLine} -javaagent:${net.bytebuddy:byte-buddy-agent:jar}</argLine>
                     <includes>
                         <include>**/*Test.class</include>
                         <include>**/*Spec.class</include>
                     </includes>
+                    <!--suppress MavenModelInspection -->
+                    <argLine>@{argLine} -javaagent:${net.bytebuddy:byte-buddy-agent:jar} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>
         </plugins>
@@ -179,6 +180,12 @@
             <artifactId>groovy-all</artifactId>
             <version>4.0.32</version>
             <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
# Java Version Upgrade — Executive Report  
  
**Project:** `download-server` (com.nurkiewicz.download)  
**Date:** 2026-06-29  
**Upgrade Path:** Java 8 / Spring Boot 2.x → Java 25 / Spring Boot 3.5  
  
---  
  
## 1. 📋 Executive Summary  
  
The `download-server` Maven application was successfully modernised from a legacy Java 8 / Spring Boot 2.x baseline to **Java 25 (OpenJDK 25.0.3)** and **Spring Boot 3.5.16** in a fully automated, non-interactive pipeline. OpenRewrite recipes handled all `pom.xml` structural changes, while Amazon Kiro CLI validated the build and tests. The upgrade completed with **zero compilation errors** and **12/12 tests passing**, confirming full functional parity with the original application.  
  
---  
  
## 2. 🔧 Application Changes  
  
- 🔄 **Java source/target** updated from 8 → **25** (`<java.version>25</java.version>`)  
- ⬆️ **Spring Boot parent** upgraded incrementally: 2.4 → 2.5 → 2.6 → 2.7 → 3.0 → 3.1 → 3.2 → 3.3 → 3.4 → **3.5.16**  
- 🧪 **JUnit 4 → JUnit 5** migration applied (`SpringBoot2JUnit4to5Migration` / `JUnit4to5Migration`)  
- 🚫 **JUnit 4 exclusion** added via `ExcludeJUnit4UnlessUsingTestcontainers` / `ExcludeDependency`  
- 🤖 **Mockito Java agent** wired into Maven Surefire (`AddMockitoJavaAgentToMavenSurefirePlugin`) to support Java 25 runtime agent requirements  
- 📦 **maven-compiler-plugin** kept at 3.15.0 with `<release>25</release>`  
  
---  
  
## 3. 🛠️ Tools Used  
  
| Tool | Version | Role |  
|------|---------|------|  
| ☕ **OpenJDK** | 25.0.3 | Target runtime & compiler |  
| 📦 **Apache Maven** | 3.9.8 (via wrapper) | Build system |  
| 🔁 **OpenRewrite** | 6.42.0 | Automated code & POM transformation |  
| 🍃 **Spring Boot** | 3.5.16 | Target application framework |  
| 🤖 **Amazon Kiro CLI** | 2.0.1 | AI-assisted build validation & report generation |  
  
- **OpenRewrite recipes applied:**  
  - `com.amazonaws.java.migrate.UpgradeToJava25`  
  - `com.amazonaws.java.spring.boot.UpgradeSpringBoot` (full chain 2.4 → 3.5)  
  
---  
  
## 4. 💻 Code Changes  
  
All changes were confined to **`pom.xml`** — no application source files required modification:  
  
- ✅ `<java.version>` property set to `25`  
- ✅ `spring-boot-starter-parent` version bumped to `3.5.16`  
- ✅ Surefire plugin `<argLine>` updated with `-javaagent:${net.bytebuddy:byte-buddy-agent:jar} -javaagent:${org.mockito:mockito-core:jar}` for Java 25 instrumentation compatibility  
- ✅ JUnit 4 transitive dependency excluded from the dependency tree  
- ✅ Groovy/Spock test suite (`DownloadControllerSpec`, 12 tests) remained fully compatible — no changes needed  
  
---  
  
## 5. ⏱️ Time Savings Estimate  
  
| Activity | Manual Estimate | Automated (Actual) | Savings |  
|----------|----------------|-------------------|---------|  
| POM version research & updates | ~2 hrs | ~1 min | **~2 hrs** |  
| Spring Boot incremental migration (8 versions) | ~4 hrs | ~2 min | **~4 hrs** |  
| JUnit 4→5 migration | ~1 hr | ~0 min (recipe) | **~1 hr** |  
| Surefire / agent configuration for Java 25 | ~30 min | ~0 min (recipe) | **~30 min** |  
| Build validation & fix cycle | ~1 hr | ~1 min (Kiro CLI) | **~1 hr** |  
| **Total** | **~8.5 hrs** | **~4 mins** | **🟢 ~8+ hrs saved** |  
  
> OpenRewrite self-reported estimate: **5m saved per recipe run** (2 runs). Actual end-to-end automation time: ~4 minutes of tool execution.  
  
---  
  
## 6. 🚀 Next Steps  
  
### ✅ Validation  
- 🔍 Run integration/smoke tests against a deployed instance to confirm HTTP endpoint behaviour under Java 25  
- 📊 Review `target/rewrite/datatables/` reports for any flagged but unapplied suggestions  
- ⚠️ Address runtime warnings: `sun.misc.Unsafe::objectFieldOffset` (Guava 29.0-jre / Caffeine 2.9.3) — upgrade Guava to 33.x and review Caffeine version  
  
### 🔧 Improvement Recommendations  
- ⬆️ **Upgrade `commons-io`** from 2.4 → 2.16+ (security & Java 25 compatibility)  
- ⬆️ **Upgrade Guava** from 29.0-jre → 33.x to eliminate `sun.misc.Unsafe` deprecation warnings  
- 🗑️ **Remove `cglib-nodep` 3.1** — obsolete with Spring 6 (uses built-in CGLIB); Spring Boot 3.x no longer requires it externally  
- 🔒 Consider adding **Spring Security** starter if authentication is needed (not currently present)  
- 📝 Replace stub `FileSystemStorage` with a real implementation before production deployment  
- 🧹 Clean up unused `<spring.version>4.1.1.RELEASE</spring.version>` property in `pom.xml` (overridden by Boot BOM)  
