### PR TITLE
Upgrade Java version to 25 on iteration 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,24 +5,70 @@
     <artifactId>download-server</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <properties>
+        <argLine></argLine>
+        <java.version>25</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>4.1.1.RELEASE</spring.version>
     </properties>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.2.3.RELEASE</version>
+        <version>3.5.16</version>
         <relativePath/>
     </parent>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.groovy</groupId>
+                <artifactId>groovy</artifactId>
+                <version>4.0.32</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>4.0.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>addTestSources</goal>
+                            <goal>compileTests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.0</version>
+                <version>3.15.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!--suppress MavenModelInspection -->
+                    <argLine>@{argLine} -javaagent:${net.bytebuddy:byte-buddy-agent:jar}</argLine>
+                    <includes>
+                        <include>**/*Test</include>
+                        <include>**/*Spec</include>
+                    </includes>
                 </configuration>
             </plugin>
         </plugins>
@@ -38,17 +84,16 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>4.1.6.RELEASE</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-spring</artifactId>
-            <version>1.0-groovy-2.4</version>
+            <version>2.4-groovy-4.0</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy-all</artifactId>
+                    <groupId>org.apache.groovy</groupId>
+                    <artifactId>groovy</artifactId>
                 </exclusion>
             </exclusions>
             <scope>test</scope>
@@ -61,22 +106,23 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>1.2.3.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>1.2.3.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>1.2.3.RELEASE</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework</groupId>
@@ -88,13 +134,13 @@
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>1.0-groovy-2.4</version>
+            <version>2.4-groovy-4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>29.0-jre</version>
         </dependency>
         <dependency>
             <groupId>cglib</groupId>
@@ -104,53 +150,39 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
-            <version>4.1.6.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>4.1.6.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context-support</artifactId>
-            <version>4.1.6.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>4.1.6.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>4.1.6.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>
-            <version>4.1.6.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>4.1.6.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-expression</artifactId>
-            <version>4.1.6.RELEASE</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>4.1.6.RELEASE</version>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.4.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/nurkiewicz/download/DownloadController.java
+++ b/src/main/java/com/nurkiewicz/download/DownloadController.java
@@ -1,6 +1,5 @@
 package com.nurkiewicz.download;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +24,6 @@ public class DownloadController {
 
 	private final FileStorage storage;
 
-	@Autowired
 	public DownloadController(FileStorage storage) {
 		this.storage = storage;
 	}

--- a/src/main/java/com/nurkiewicz/download/MainApplication.java
+++ b/src/main/java/com/nurkiewicz/download/MainApplication.java
@@ -7,7 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 class MainApplication {
 
 	public static void main(String[] args) {
-		Integer temp = new Integer("1234");
+		Integer temp = Integer.valueOf("1234");
 		SpringApplication.run(MainApplication.class, args);
 	}
 }

--- a/src/test/java/com/nurkiewicz/download/FileExamples.java
+++ b/src/test/java/com/nurkiewicz/download/FileExamples.java
@@ -6,9 +6,9 @@ import java.util.UUID;
 
 public class FileExamples {
 
-	public static final UUID TXT_FILE_UUID = UUID.randomUUID();
+	public static final UUID TXT_FILE_UUID = UUID.fromString("11111111-1111-1111-1111-111111111111");
 	public static final FilePointer TXT_FILE = txtFile();
-	public static final UUID NOT_FOUND_UUID = UUID.randomUUID();
+	public static final UUID NOT_FOUND_UUID = UUID.fromString("22222222-2222-2222-2222-222222222222");
 
 	private static FileSystemPointer txtFile() {
 		final URL resource = FileStorageStub.class.getResource("/download.txt");

--- a/src/test/java/org/springframework/web/filter/Sha512ShallowEtagHeaderFilter.java
+++ b/src/test/java/org/springframework/web/filter/Sha512ShallowEtagHeaderFilter.java
@@ -2,11 +2,16 @@ package org.springframework.web.filter;
 
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
+import com.google.common.io.ByteStreams;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 public class Sha512ShallowEtagHeaderFilter extends ShallowEtagHeaderFilter {
 
 	@Override
-	protected String generateETagHeaderValue(byte[] bytes) {
+	protected String generateETagHeaderValue(InputStream inputStream, boolean isWeak) throws IOException {
+		final byte[] bytes = ByteStreams.toByteArray(inputStream);
 		final HashCode hash = Hashing.sha512().hashBytes(bytes);
 		return "\"" + hash + "\"";
 	}

--- a/summary.md
+++ b/summary.md
@@ -1,0 +1,34 @@
+# Java 25 Migration Summary
+
+## Status: BUILD SUCCESS — 12/12 tests passing
+
+## Changes Made
+
+### 1. pom.xml — Groovy/Spock upgrade
+- Replaced `org.codehaus.groovy:groovy-all:2.4.16` with `org.apache.groovy:groovy:4.0.32` (new groupId for Groovy 4, test scope only)
+- Upgraded `spock-core` and `spock-spring` from `1.0-groovy-2.4` to `2.4-groovy-4.0` (required for JUnit 5 / JUnit Platform support)
+- Added `gmavenplus-plugin:4.0.1` (`addTestSources` + `compileTests` goals) so Groovy test sources in `src/test/groovy` are compiled
+- Updated Surefire `<includes>` to `**/*Test` and `**/*Spec` so Spock `*Spec` classes are discovered and executed
+
+### 2. Sha512ShallowEtagHeaderFilter.java
+- Updated `generateETagHeaderValue` override from the removed Spring 5 `byte[]` signature to the Spring 6 `InputStream + boolean` signature
+- Reads all bytes from the `InputStream` using Guava `ByteStreams.toByteArray`, then computes SHA-512 hash
+
+### 3. FileExamples.java
+- Changed `TXT_FILE_UUID` and `NOT_FOUND_UUID` from `UUID.randomUUID()` to fixed `UUID.fromString(...)` constants
+- **Root cause**: Spock 2 + Spring's test context uses classloader isolation; `UUID.randomUUID()` produced different values in the Spring bean classloader vs the test classloader, causing all `TXT_FILE_UUID` lookups in `FileStorageStub` to miss. Fixed UUIDs compare by value (not identity) so they match across classloaders.
+
+## Build Verification
+
+```
+./mvnw clean test
+Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
+BUILD SUCCESS
+```
+
+## Next Steps / Notes
+
+- The `logback.xml` file has a missing `name` attribute on an `<appender>` element (non-fatal at test time, logged as ERROR by Logback). This is unrelated to the Java 25 migration.
+- `commons-io:2.4` and `guava:29.0-jre` are older versions; consider upgrading in a subsequent cycle for security patches.
+- `cglib-nodep:3.1` is obsolete; Spring 6 / Spring Boot 3 uses its own CGLIB fork. This dependency can be removed.
+- The `spring.version=4.1.1.RELEASE` property in pom.xml is overridden by the Spring Boot parent BOM (6.2.19 is the effective version). The property is unused and can be removed.


### PR DESCRIPTION
# 🚀 Java Version Upgrade — Executive Report  
  
**Project:** `com.nurkiewicz.download:download-server`  
**Date:** 2026-06-29  
**Upgrade path:** Java 8 + Spring Boot 1.x → **Java 25 + Spring Boot 3.5.16**  
  
---  
  
## 📋 Executive Summary  
  
A legacy Java 8 Maven web application (a file download server built on Spring Boot 1.x) was successfully upgraded end-to-end to **Java 25** and **Spring Boot 3.5.16**. The automated tooling (OpenRewrite) handled the bulk of the build configuration and source-code transformations in under 8 minutes across two recipe passes. Amazon Kiro CLI then identified and resolved the remaining post-migration issues — an incompatible Groovy/Spock test toolchain and a Spring 6 API breakage — bringing the build to a clean **✅ BUILD SUCCESS with 12/12 tests passing**.  
  
---  
  
## 🗂️ Application Changes  
  
- 🏗️ **Spring Boot:** `1.x` → `3.5.16` (via incremental upgrade chain: 2.0 → 2.1 → … → 3.5)  
- ☕ **Java version:** `8` → `25` (`java.version` property + `maven-compiler-plugin` release flag)  
- 🔄 **Jakarta EE migration:** `javax.servlet` imports replaced with `jakarta.servlet` via `JavaxServletToJakartaServlet` recipe  
- 🧹 **Source code:** `new Integer(...)` constructor replaced with `Integer.valueOf(...)` (`PrimitiveWrapperClassConstructorToValueOf`)  
- 🔌 **Maven plugins upgraded:** `maven-compiler-plugin`, `maven-dependency-plugin`, `maven-surefire-plugin` (all brought to Java 25-compatible versions)  
- 🛡️ **Mockito agent:** `AddMockitoJavaAgentToMavenSurefirePlugin` recipe injected the byte-buddy agent `argLine` configuration  
- 🧪 **Test toolchain rebuilt:** Groovy 2.4 + Spock 1.0 upgraded to **Groovy 4.0.32** + **Spock 2.4-groovy-4.0**; GMavenPlus plugin added to compile `src/test/groovy`  
  
---  
  
## 🛠️ Tools Used  
  
| Tool | Version | Role |  
|---|---|---|  
| ☕ **Amazon Corretto / OpenJDK** | Java 25 | Target runtime |  
| 🔁 **OpenRewrite** | `6.42.0` | Automated source & POM transformations |  
| 📦 **OpenRewrite recipes** | `com.amazonaws.java.migrate.UpgradeToJava25`, `com.amazonaws.java.spring.boot.UpgradeSpringBoot` | Java 25 + Spring Boot 3.5 migration recipes |  
| 🤖 **Amazon Kiro CLI** | `2.0.1` (model: `claude-sonnet-4-5`) | Post-migration build fix & report generation |  
| 🔧 **Apache Maven** | `3.9.8` (via `mvnw` wrapper) | Build and test execution |  
  
---  
  
## 💻 Code Changes  
  
### `pom.xml`  
- ✅ `java.version` property: `8` → `25`  
- ✅ Spring Boot parent: `1.x` → `3.5.16`  
- ✅ `jakarta.servlet-api` dependency added (OpenRewrite)  
- ✅ `maven-compiler-plugin`: `3.0` → `3.15.0` with `<release>25</release>`  
- ✅ Groovy groupId: `org.codehaus.groovy:groovy-all:2.4.16` → `org.apache.groovy:groovy:4.0.32`  
- ✅ Spock: `spock-core` / `spock-spring` `1.0-groovy-2.4` → `2.4-groovy-4.0`  
- ✅ `gmavenplus-plugin:4.0.1` added (`addTestSources` + `compileTests` goals)  
- ✅ Surefire `<includes>` updated to `**/*Test` and `**/*Spec` to discover Spock specs  
  
### `src/main/java/.../MainApplication.java`  
- ✅ `new Integer("1234")` → `Integer.valueOf("1234")` (deprecated constructor removed)  
  
### `src/main/java/.../DownloadController.java`  
- ✅ `@Autowired` removed from constructor (Spring Boot 3 best practice)  
  
### `src/test/java/.../Sha512ShallowEtagHeaderFilter.java`  
- ✅ Override updated from removed Spring 5 signature `generateETagHeaderValue(byte[])` to Spring 6 signature `generateETagHeaderValue(InputStream, boolean)`  
  
### `src/test/java/.../FileExamples.java`  
- ✅ `UUID.randomUUID()` → `UUID.fromString("fixed-uuid")` for both `TXT_FILE_UUID` and `NOT_FOUND_UUID` — fixes classloader isolation issue in Spock 2 where the Spring context and test class load `FileExamples` independently, producing different random UUIDs  
  
---  
  
## ⏱️ Time Savings Estimate  
  
| Phase | Estimated Manual Effort | Automated Duration |  
|---|---|---|  
| Java 25 POM + source migration (OpenRewrite) | ~1h | 1m 49s |  
| Spring Boot 2.x→3.5 incremental upgrade (OpenRewrite) | ~2h 22m | 5m 21s |  
| Post-migration build fixes (Kiro CLI) | ~2–4h manual investigation | 13m 37s |  
| **Total** | **~5.5–7.5 hours** | **~21 minutes** |  
  
> 💡 **Estimated time saved: ~5–7 hours** vs fully manual upgrade. OpenRewrite self-reported savings of `1h` and `2h 22m`. Kiro CLI resolved 3 non-trivial post-migration issues (Groovy toolchain, Spring 6 API break, classloader UUID bug) that would have required significant manual debugging.  
  
---  
  
## 🔜 Next Steps  
  
### Validation  
- 🔍 Run integration / smoke tests against a deployed instance to verify runtime behaviour  
- 🔍 Verify `logback.xml` — a non-fatal `Missing attribute [name]` error is logged; the `<appender>` element needs a `name` attribute added  
  
### Recommended Follow-ups  
- 🧹 Remove the unused `<spring.version>4.1.1.RELEASE</spring.version>` property — it is overridden by the Spring Boot BOM and misleading  
- 🧹 Remove `cglib-nodep:3.1` dependency — Spring Boot 3 bundles its own CGLIB fork; this is a dead transitive  
- ⬆️ Upgrade `commons-io:2.4` → `2.17+` (multiple CVEs in older versions)  
- ⬆️ Upgrade `guava:29.0-jre` → `33.x` (security and `sun.misc.Unsafe` deprecation warnings)  
- ⬆️ Consider replacing `com.google.common.hash.Hashing.sha512()` with `java.security.MessageDigest` — Guava's `Hashing` API uses `sun.misc.Unsafe` internally which will be blocked in a future JDK release  
- 📋 Address remaining `sun.misc.Unsafe` JVM warnings for forward compatibility with JDK 26+  

## Credit usage

💳 Kiro CLI credits used: 10.72  
